### PR TITLE
Replace bs4 with beautifulsoup4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
-bs4
+beautifulsoup4
 xlsxwriter
 urllib3<2


### PR DESCRIPTION
`bs4` is a [dummy package](https://pypi.org/project/bs4/) which points to beautifulsoup4. Distributions usually don't ship `bs4`.